### PR TITLE
refactor(arg): disallow trailing flags for CommaConfigs

### DIFF
--- a/pkg/impl/arg/arg.go
+++ b/pkg/impl/arg/arg.go
@@ -77,7 +77,7 @@ type (
 		// Type is the type of the flag.
 		Type Type
 		// Default is the default value of the flag, and is used if the flag
-		// doesn't putContext set.
+		// isn't set.
 		//
 		// If Default is (interface{})(nil), Type.Default() will be used.
 		Default interface{}
@@ -96,7 +96,7 @@ type (
 		// Type is the type of the flag.
 		Type Type
 		// Default is the default value of the flag, and is used if the flag
-		// doesn't putContext set.
+		// isn't set.
 		//
 		// If Default is (interface{})(nil), Type.Default() will be used.
 		Default interface{}

--- a/pkg/impl/arg/comma_config.go
+++ b/pkg/impl/arg/comma_config.go
@@ -13,20 +13,15 @@ import (
 // separate flags and arguments.
 // Literal commas can be escaped using a double comma (',,').
 //
-// Flags can be placed both at the beginning and the end of the arguments.
-// Their names mustn't contain double minuses, commas or whitespace.
+// Flags may be placed in front of the arguments.
 //
-// Additionally, in order to distinguish flags from arguments argument that
-// start with a minus must be escaped using a double minus.
-// To ease usability for users unaware of this escapes are not needed if one
-// of the following conditions is fulfilled:
+// If the first argument starts with a minus, the minus must be escaped
+// through a double minus to avoid confusion with a flag.
 //
-// 1. The minus is used in any of the required arguments except the first.
+// Examples
 //
-// 2. There are no flags.
-//
-// Even if one of those exceptions applies, double minuses will still be parsed
-// as a single minus to preserve predictability.
+// cmd -flag1 abc, -flag2, first arg, second arg,, with a comma in it
+// cmd --first arg using a minus escape
 type CommaConfig struct {
 	// Required contains the required arguments.
 	Required []RequiredArg
@@ -63,20 +58,15 @@ func (c CommaConfig) Info(l *i18n.Localizer) []plugin.ArgsInfo {
 // separate flags and arguments.
 // Literal commas can be escaped using a double comma (',,').
 //
-// Flags can be placed both at the beginning and the end of the arguments.
-// Their names mustn't contain double minuses, commas or whitespace.
+// Flags may be placed in front of the arguments.
 //
-// Additionally, in order to distinguish flags from arguments argument that
-// start with a minus must be escaped using a double minus.
-// To ease usability for users unaware of this escapes are not needed if one
-// of the following conditions is fulfilled:
+// If the first argument starts with a minus, the minus must be escaped
+// through a double minus to avoid confusion with a flag.
 //
-// 1. The minus is used in any of the required arguments except the first.
+// Examples
 //
-// 2. There are no flags.
-//
-// Even if one of those exceptions applies, double minuses will still be parsed
-// as a single minus to preserve predictability.
+// cmd -flag1 abc, -flag2, first arg, second arg,, with a comma in it
+// cmd --first arg using a minus escape
 type LocalizedCommaConfig struct {
 	// Required contains the required arguments.
 	Required []LocalizedRequiredArg

--- a/pkg/impl/arg/comma_config_test.go
+++ b/pkg/impl/arg/comma_config_test.go
@@ -328,7 +328,7 @@ func TestCommaConfig_Parse(t *testing.T) {
 					},
 				},
 			},
-			rawArgs:    "-test2 abc, 123, def, 456, -test 789",
+			rawArgs:    "-test2 abc, -test 789, 123, def, 456",
 			expectArgs: plugin.Args{123, "def", 456, "ghi"},
 			expectFlags: plugin.Flags{
 				"test":  789,
@@ -386,7 +386,7 @@ func TestCommaConfig_Parse(t *testing.T) {
 			},
 		},
 		{
-			name: "no minus escape required arg",
+			name: "no minus escape in second arg",
 			config: CommaConfig{
 				Required: []RequiredArg{
 					{
@@ -394,7 +394,7 @@ func TestCommaConfig_Parse(t *testing.T) {
 						Type: mockTypeString,
 					},
 					{
-						Name: "arg1",
+						Name: "arg2",
 						Type: mockTypeString,
 					},
 				},
@@ -410,19 +410,6 @@ func TestCommaConfig_Parse(t *testing.T) {
 			expectFlags: plugin.Flags{
 				"test": 0,
 			},
-		},
-		{
-			name: "no minus escape if no flag",
-			config: CommaConfig{
-				Required: []RequiredArg{
-					{
-						Name: "arg1",
-						Type: mockTypeString,
-					},
-				},
-			},
-			rawArgs:    "-abc",
-			expectArgs: plugin.Args{"-abc"},
 		},
 	}
 
@@ -1053,7 +1040,7 @@ func TestLocalizedCommaConfig_Parse(t *testing.T) {
 					},
 				},
 			},
-			rawArgs:    "-test2 abc, 123, def, 456, -test 789",
+			rawArgs:    "-test2 abc, -test 789, 123, def, 456",
 			expectArgs: plugin.Args{123, "def", 456, "ghi"},
 			expectFlags: plugin.Flags{
 				"test":  789,
@@ -1111,7 +1098,7 @@ func TestLocalizedCommaConfig_Parse(t *testing.T) {
 			},
 		},
 		{
-			name: "no minus escape required arg",
+			name: "no minus in second arg",
 			config: LocalizedCommaConfig{
 				Required: []LocalizedRequiredArg{
 					{
@@ -1135,19 +1122,6 @@ func TestLocalizedCommaConfig_Parse(t *testing.T) {
 			expectFlags: plugin.Flags{
 				"test": 0,
 			},
-		},
-		{
-			name: "no minus escape if no flag",
-			config: LocalizedCommaConfig{
-				Required: []LocalizedRequiredArg{
-					{
-						Name: i18n.NewFallbackConfig("", "arg1"),
-						Type: mockTypeString,
-					},
-				},
-			},
-			rawArgs:    "-abc",
-			expectArgs: plugin.Args{"-abc"},
 		},
 	}
 

--- a/pkg/impl/arg/comma_parser.go
+++ b/pkg/impl/arg/comma_parser.go
@@ -22,14 +22,14 @@ type commaParser struct {
 func newCommaParser(args string, cfg CommaConfig, s *state.State, ctx *plugin.Context) *commaParser {
 	return &commaParser{
 		helper: newParseHelper(cfg.Required, cfg.Optional, cfg.Flags, cfg.Variadic, s, ctx),
-		lexer:  newCommaLexer(args, len(cfg.Required), len(cfg.Flags) > 0),
+		lexer:  newCommaLexer(args),
 	}
 }
 
 func newCommaParserl(args string, cfg LocalizedCommaConfig, s *state.State, ctx *plugin.Context) *commaParser {
 	return &commaParser{
 		helper: newParseHelperl(cfg.Required, cfg.Optional, cfg.Flags, cfg.Variadic, s, ctx),
-		lexer:  newCommaLexer(args, len(cfg.Required), len(cfg.Flags) > 0),
+		lexer:  newCommaLexer(args),
 	}
 }
 
@@ -39,7 +39,7 @@ func (p *commaParser) parse() error {
 		return err
 	}
 
-	return p.helper.putContext()
+	return p.helper.store()
 }
 
 func (p *commaParser) startParse() error {

--- a/pkg/impl/arg/parse_helper.go
+++ b/pkg/impl/arg/parse_helper.go
@@ -178,7 +178,8 @@ func newParseHelperl( //nolint:dupl
 	return p
 }
 
-func (h *parseHelper) putContext() error {
+// store stores the parsed arguments in the context.
+func (h *parseHelper) store() error {
 	if h.variadicSlice.IsValid() {
 		h.args = append(h.args, h.variadicSlice.Interface())
 	}

--- a/pkg/impl/arg/shellword_parser.go
+++ b/pkg/impl/arg/shellword_parser.go
@@ -85,7 +85,7 @@ func (p *shellwordParser) parse() error {
 		return err
 	}
 
-	return p.helper.putContext()
+	return p.helper.store()
 }
 
 // has checks if there are at least min runes remaining.


### PR DESCRIPTION
This PR removes the possibility of using trailing flags in comma-based ArgConfigs. This greatly reduces the number of times minus escapes are needed, since now only the first argument will need to use them.